### PR TITLE
Add GitHub Pages workflow to deploy research-visualization Vite app

### DIFF
--- a/.github/workflows/deploy-research-visualization.yml
+++ b/.github/workflows/deploy-research-visualization.yml
@@ -1,0 +1,56 @@
+name: Deploy research-visualization to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: research-visualization
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: research-visualization/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: research-visualization/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Provide an automated way to build and publish the `research-visualization` Vite app to GitHub Pages on pushes to `main`/`master`.
- Ensure the built `dist` output from the `research-visualization` folder is uploaded and deployed via GitHub Actions.

### Description
- Add `.github/workflows/deploy-research-visualization.yml` which checks out the repo, sets up Node 20, runs `npm ci` and `npm run build` inside `research-visualization`, and uploads `research-visualization/dist` as the Pages artifact.
- The workflow uses `actions/upload-pages-artifact@v3` to upload the build and `actions/deploy-pages@v4` to publish the site, and is triggered on push to `main`/`master` and via `workflow_dispatch`.
- The repository already contains `research-visualization/package.json` with a `predeploy`/`deploy` script and `vite.config.ts` with `base: '/zonui-3b/'` to support proper routing for Pages.

### Testing
- No automated tests were executed in this environment because GitHub Actions workflows run on GitHub and the workflow has not been triggered here.
- The workflow will run automatically when the change is pushed to `main` or `master`, and success/failure can be observed in the GitHub Actions run logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695723195b088333ac78bc06064c9907)